### PR TITLE
Wrap highlighted text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ node_modules/
 .DS_Store
 _book/*
 book.pdf
+book.aux
+book.log
+book.tex
+book.toc

--- a/latex-conf/head.tex
+++ b/latex-conf/head.tex
@@ -1,6 +1,4 @@
-% change background color for inline code in
-% markdown files. The following code does not work well for
-% long text as the text will exceed the page boundary
+% change background color for inline code in markdown files. 
 \usepackage{soul}
 \definecolor{bgcolor}{HTML}{E0E0E0}
 \sethlcolor{bgcolor}
@@ -11,8 +9,13 @@
   \oldtexttt{\hl{#1}}
 }
 
+% Make all images that have a caption float
 \usepackage{float}
 \floatplacement{figure}{H}
+
+% Wrap code blocks
+\usepackage{fvextra}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,commandchars=\\\{\}}
 
 \usepackage{titlesec}
 \newcommand{\sectionbreak}{\clearpage}

--- a/latex-conf/head.tex
+++ b/latex-conf/head.tex
@@ -1,11 +1,14 @@
 % change background color for inline code in
 % markdown files. The following code does not work well for
 % long text as the text will exceed the page boundary
+\usepackage{soul}
 \definecolor{bgcolor}{HTML}{E0E0E0}
+\sethlcolor{bgcolor}
+
 \let\oldtexttt\texttt
 
 \renewcommand{\texttt}[1]{
-  \colorbox{bgcolor}{\oldtexttt{#1}}
+  \oldtexttt{\hl{#1}}
 }
 
 \usepackage{float}


### PR DESCRIPTION
Make sure the inline code blocks wrap to the next line when they would otherwise go out of the page.

Does the same for the normal code blocks, where latex adds a character to indicate that the piece of code belongs to the previous line.