### PR TITLE
Center images on gitbook

### DIFF
--- a/assets/css/website.css
+++ b/assets/css/website.css
@@ -1,0 +1,5 @@
+img {
+  display: block;
+  margin: auto;
+}
+

--- a/book.json
+++ b/book.json
@@ -7,5 +7,8 @@
 	    "ga": {
 			"token": "UA-154019382-1"
 		}
-	  }
+	},
+    "styles": {
+        "website": "assets/css/website.css"
+    }
 }


### PR DESCRIPTION
I added a css file that centers all the images.
We cannot easily have images that are not centered on gitbook now, is this something we would want to be able to do?

Closes #33 