### PR TITLE
Add missing text for non-binary choices and final guidelines video

### DIFF
--- a/chapters/testing-techniques/model-based-testing.md
+++ b/chapters/testing-techniques/model-based-testing.md
@@ -288,14 +288,13 @@ public void pricePerMonthTest(boolean international, boolean autoRenewal,
  
 ### Non-binary choices and final guidelines
 
-So far, all the decision tables dicussed have boolean conditions; the values in the cells are either `true` or `false`.
-The decision tables can easily be generalized to contain non-boolean values (non-binary choices) as well.
-Instead of only `true` and `false` the values can now also be, for example, a number.
+So far, all the decision tables dicussed have boolean conditions (i.e., values in the cells were either `true` or `false`).
+The decision tables can be generalized to contain non-boolean values (non-binary choices). In other words, instead of only `true` and `false`, the values can now also be, e.g., a number.
 
 Take the decision table for the phone subscriptions, discussed earlier.
-Initially this only contained the international and auto-renewal conditions.
+Initially, this only contained the international and auto-renewal conditions.
 A non-boolean can be introduced to represent a data limit.
-The amount of data can be unlimited (&infin;), 8 GB, or 0 GB.
+The amount of data can be unlimited (&infin;), 8 GB, or none (0 GB).
 
 <table>
   <tr><th></th><th></th><th colspan="6">Variants</th></tr>
@@ -306,29 +305,28 @@ The amount of data can be unlimited (&infin;), 8 GB, or 0 GB.
   <tr><td><i>Action</i></td><td>price / month</td><td>32<br></td><td>30</td><td>12</td><td>10</td><td>17</td><td>15</td></tr>
 </table>
 
-With two boolean conditions and one condition with three possible values, the possible amount of variants is $$2 \cdot 2 \cdot 3 = 12$$.
+With two boolean conditions and one condition with three possible values, the possible number of variants is $$2 \cdot 2 \cdot 3 = 12$$.
 The decision table only shows $$6$$.
 The unspecified columns implicitly represent invalid combinations.
-So, an international subscription without data would not be possible.
+For example, an international subscription without data would not be possible.
 
 In small decision tables, non-boolean conditions can be useful.
-However, with many non-boolean conditions, the amount of possible combinations in the decision table can grow very large.
+However, with many non-boolean conditions, the amount of possible combinations in the decision table can be large.
 Due to this combinatorial explosion of possible variants, the decision table becomes very hard to work with.
 For example, a decision table with three conditions, each having $$4$$ possible values, results in $$4 \cdot 4 \cdot 4 = 64$$ possible combinations.
-In such case, other strategies like pair-wise combinatorial testing offer better scalability. 
+In such case, other strategies like _pair-wise combinatorial testing_ offer better scalability. 
 
-The testing techniques for the decision tables with only boolean conditions can also be generalized to tables with non-boolean conditions.
-For MC/DC this requires modifying one of its three properties: Instead of making each condition `true` and `false` at least once in the test suite, each condition should be made each of its possible values at least once in the test suite.
-The other two requirements stay the same.
+The testing techniques for decision tables with only boolean conditions can also be generalized to tables with non-boolean conditions.
+For the MC/DC criteria (discussed in the structural testing chapter), this requires modifying one of its three properties: instead of making each condition `true` and `false` at least once in the test suite, each of its possible values should appear at least once in the test suite.
 
 Finally, these are some general quidelines to keep in mind when designing decision tables:
 
-1. Keep conditions independent. The order of the conditions should not matter, otherwise a state machine might be more fitting.
-2. Use DC values when possible. This decreases the amount of variants, making the decision table easier to read and easier to understand.
-3. Variants with DC values should not overlap. If they do, they should at least have the same action.
-4. Add a default column. This provides an action for the variants that are not in the decision table, allowing the decision table to not include all possible variants.
-5. Consider non-boolean conditions if conditions are mutually exclusive. Mutually means that the conditions can never be true at the same time. These conditions then probably encode a single non-boolean condition.
-6. If most conditions are non-boolean, consider using a different combinatorial testing technique instead. One example would be pair-wise testing.
+1. **Keep conditions independent.** The order of the conditions should not matter, otherwise a state machine might be more fitting.
+2. **Use DC values when possible.** This decreases the amount of variants, making the decision table easier to read and easier to understand.
+3. **Variants with DC values should not overlap.** If they do, they should at least have the same action.
+4. **Add a default column.** This provides an action for the variants that are not in the decision table, allowing the decision table to not include all possible variants.
+5. **Consider non-boolean conditions if conditions are mutually exclusive.** Mutually means that the conditions can never be true at the same time. These conditions then probably encode a single non-boolean condition.
+6. **If most conditions are non-boolean, consider using a different combinatorial testing technique instead**. One example would be pair-wise testing.
 
 {% set video_id = "RHB_HaGfNjM" %}
 {% include "/includes/youtube.md" %}

--- a/chapters/testing-techniques/model-based-testing.md
+++ b/chapters/testing-techniques/model-based-testing.md
@@ -287,13 +287,49 @@ public void pricePerMonthTest(boolean international, boolean autoRenewal,
 {% include "/includes/youtube.md" %}
  
 ### Non-binary choices and final guidelines
- 
-{% hint style='working' %}
-Write the video's accompanying text
-{% endhint %}
- 
- 
- 
+
+So far, all the decision tables dicussed have boolean conditions; the values in the cells are either `true` or `false`.
+The decision tables can easily be generalized to contain non-boolean values (non-binary choices) as well.
+Instead of only `true` and `false` the values can now also be, for example, a number.
+
+Take the decision table for the phone subscriptions, discussed earlier.
+Initially this only contained the international and auto-renewal conditions.
+A non-boolean can be introduced to represent a data limit.
+The amount of data can be unlimited (&infin;), 8 GB, or 0 GB.
+
+<table>
+  <tr><th></th><th></th><th colspan="6">Variants</th></tr>
+  <tr><td rowspan="3"><br><i>Conditions</i></td>
+  <td>International</td><td>T</td><td>T</td><td>F<br></td><td>F</td><td>F</td><td>F</td></tr>
+  <tr><td>Auto-renewal</td><td>T<br></td><td>F</td><td>T</td><td>T</td><td>F</td><td>F</td></tr>
+  <tr><td>Data limit</td><td>&infin;</td><td>&infin;</td><td>8</td><td>0</td><td>8</td><td>0</td></tr>
+  <tr><td><i>Action</i></td><td>price / month</td><td>32<br></td><td>30</td><td>12</td><td>10</td><td>17</td><td>15</td></tr>
+</table>
+
+With two boolean conditions and one condition with three possible values, the possible amount of variants is $$2 \cdot 2 \cdot 3 = 12$$.
+The decision table only shows $$6$$.
+The unspecified columns implicitly represent invalid combinations.
+So, an international subscription without data would not be possible.
+
+In small decision tables, non-boolean conditions can be useful.
+However, with many non-boolean conditions, the amount of possible combinations in the decision table can grow very large.
+Due to this combinatorial explosion of possible variants, the decision table becomes very hard to work with.
+For example, a decision table with three conditions, each having $$4$$ possible values, results in $$4 \cdot 4 \cdot 4 = 64$$ possible combinations.
+In such case, other strategies like pair-wise combinatorial testing offer better scalability. 
+
+The testing techniques for the decision tables with only boolean conditions can also be generalized to tables with non-boolean conditions.
+For MC/DC this requires modifying one of its three properties: Instead of making each condition `true` and `false` at least once in the test suite, each condition should be made each of its possible values at least once in the test suite.
+The other two requirements stay the same.
+
+Finally, these are some general quidelines to keep in mind when designing decision tables:
+
+1. Keep conditions independent. The order of the conditions should not matter, otherwise a state machine might be more fitting.
+2. Use DC values when possible. This decreases the amount of variants, making the decision table easier to read and easier to understand.
+3. Variants with DC values should not overlap. If they do, they should at least have the same action.
+4. Add a default column. This provides an action for the variants that are not in the decision table, allowing the decision table to not include all possible variants.
+5. Consider non-boolean conditions if conditions are mutually exclusive. Mutually means that the conditions can never be true at the same time. These conditions then probably encode a single non-boolean condition.
+6. If most conditions are non-boolean, consider using a different combinatorial testing technique instead. One example would be pair-wise testing.
+
 {% set video_id = "RHB_HaGfNjM" %}
 {% include "/includes/youtube.md" %}
  


### PR DESCRIPTION
The text closely follows some of the content of the video.
Let me know if anything can be improved.

Closes #38 