### PR TITLE
Update expected value for B1.2 to 150 (3*50), was 100 (2*50) before.

### DIFF
--- a/chapters/testing-techniques/boundary-testing.md
+++ b/chapters/testing-techniques/boundary-testing.md
@@ -95,7 +95,7 @@ each boundary will require *at least* two test cases:
 
 For B1:
 * B1.1 = input={score=49, remaining lives=5}, output={99}
-* B1.2 = input={score=50, remaining lives=5}, output={100}
+* B1.2 = input={score=50, remaining lives=5}, output={150}
 
 For B2:
 * B2.1 = input={score 500, remaining lives=3}, output={200}


### PR DESCRIPTION
According to the example, the score should be tripled if the score is >= 50 and the lives are >= 3, which in this case they are. Thus, the score should be 150 at the end.
EDIT: It seems that on the consecutive lines for B2, the outputs should be 1500 and 530, instead of 200 and 130.