### PR TITLE
Updated Question 4 of Specification-Based Testing to an Open Question

### DIFF
--- a/chapters/appendix/answers.md
+++ b/chapters/appendix/answers.md
@@ -73,18 +73,21 @@ We end up with three partitions:
 
 **Exercise 4**
 
-We go over each given partition and identify whether it is a valid partition:
+There are no right or wrong answers, but a lot of decisions that we do based on what we know about the system (or, in this case, what we assume about the system).
+But, when context kicks in, there might be more possible invalid test cases then just the cases in the boundaries.
+For example:
+* Do we feel the need of testing negative numbers separately from positive numbers? From the specification, there's no reason to do so. 
+If you look at the source code (supposing you have access to the source code; we'll discuss what to do with source code next week!), does it make you feel like this test is need?
+* Do we feel the need of testing trailing zeroes? Maybe the user inputs a string which is converted later... Then, testing might be important.
+* Do we feel we need to test extreme numbers, like Integer.MAX_VALUE or even passing a long int or float there?
 
-1. Valid partition: Invalid numbers, which are too small.
-2. Valid partition: Valid numbers
-3. Invalid partition: Contains some valid numbers, but the range is too small to cover the whole partition.
-4. Invalid partition: Same reason as number 3.
-5. Valid partition: Invalid numbers, that are too large.
-6. Invalid partition: Contains both valid and invalid letters (the C is included in the domain).
-7. Valid partition: Valid letters.
-8. Valid partition: Invalid letters, past the range of valid letters.
+Examples of possible invalid partitions:
+1. [Integer.MIN_VALUE, 999]
+2. [4001, Integer.MAX_VALUE] 
+3. [A, B]
+4. [N, Z]
+5. [0000, 0999] 
 
-We have the following valid partitions: 1, 2, 5, 7, 8.
 
 **Exercise 5**
 

--- a/chapters/appendix/answers.md
+++ b/chapters/appendix/answers.md
@@ -73,20 +73,27 @@ We end up with three partitions:
 
 **Exercise 4**
 
-There are no right or wrong answers, but a lot of decisions that we do based on what we know about the system (or, in this case, what we assume about the system).
+There are no right or wrong answers to this exercise. 
+It services to show that a lot of decisions that we make are based on what we know about the system (or, in this case, what we assume about the system).
 But, when context kicks in, there might be more possible invalid test cases then just the cases in the boundaries.
+
+Whatever decisions you as a tester make regarding specific invalid test cases, it is important to justify those decisions.
 For example:
 * Do we feel the need of testing negative numbers separately from positive numbers? From the specification, there's no reason to do so. 
-If you look at the source code (supposing you have access to the source code; we'll discuss what to do with source code next week!), does it make you feel like this test is need?
+If you look at the source code (supposing you have access to the source code, does it make you feel like this test is needed?
 * Do we feel the need of testing trailing zeroes? Maybe the user inputs a string which is converted later... Then, testing might be important.
-* Do we feel we need to test extreme numbers, like Integer.MAX_VALUE or even passing a long int or float there?
+* Do we feel the need to test extreme numbers, like Integer.MAX_VALUE or even passing a long int or float there? 
+* Do we feel the need to test with a string consisting of only 1 letter, or maybe more than 2 letters? 
+If there's no input validation, unintended behaviour might be right around the corner 
+* Do we feel the need to test lowercase letters? Maybe the program can't distinguish between lower- and uppercase letters.
 
 Examples of possible invalid partitions:
 1. [Integer.MIN_VALUE, 999]
 2. [4001, Integer.MAX_VALUE] 
-3. [A, B]
+3. [AA, B]
 4. [N, Z]
 5. [0000, 0999] 
+6. [AAA, ZZZ]
 
 
 **Exercise 5**

--- a/chapters/testing-techniques/specification-based-testing.md
+++ b/chapters/testing-techniques/specification-based-testing.md
@@ -394,10 +394,13 @@ Letters are in the range `[C, M]`.
 
 Consider a program that receives two inputs: an integer (for the 4 numbers) and a string (for the 2 letters), and returns `true` (valid zip code) or `false` (invalid zip code).
 
-The boundaries for this program appear to be straight forward:
+The boundaries for this program appear to be straightforward:
 - Anything below 1000 -> invalid
 - [1000, 4000] -> valid
 - Anything above 4000 -> invalid
+- [A, B] -> invalid
+- [C, M] -> valid
+- [N, Z] -> invalid
 
 Based on what you as a tester *assume* about the program, which invalid cases can you come up with?
 Describe these invalid cases and how they might exercise the program based on your assumptions.

--- a/chapters/testing-techniques/specification-based-testing.md
+++ b/chapters/testing-techniques/specification-based-testing.md
@@ -394,22 +394,13 @@ Letters are in the range `[C, M]`.
 
 Consider a program that receives two inputs: an integer (for the 4 numbers) and a string (for the 2 letters), and returns `true` (valid zip code) or `false` (invalid zip code).
 
-A tester comes up with the following partitions:
+The boundaries for this program appear to be straight forward:
+- Anything below 1000 -> invalid
+- [1000, 4000] -> valid
+- Anything above 4000 -> invalid
 
-1. [0, 999]
-2. [1000, 4000]
-3. [2001, 3500]
-4. [3500, 3999]
-5. [4001, 9999]
-6. [A-C]
-7. [C-M]
-8. [N-Z]
-
-Note that with [a, b] all numbers between and including a and b are in the domain.
-The same goes with letters like [A-Z].
-
-Which of these partitions are valid (and good) partitions, i.e. which can actually be used as partitions?
-Name each of the valid partitions, and describe how they exercise the program.
+Based on what you as a tester *assume* about the program, which invalid cases can you come up with?
+Describe these invalid cases and how they might exercise the program based on your assumptions.
 
 **Exercise 5.**
 See a slightly modified version of the HashSet's `add()` Javadoc below.


### PR DESCRIPTION
This serves as a realization that boundaries can appear straightforward but when context kicks in, there might be more invalid cases than may appear from the boundaries. This change is based on this discussion in BrightSpace: https://brightspace.tudelft.nl/d2l/le/193712/discussions/threads/41487/View

Kind regards,
Mark Bongers & Danny Breunissen