### PR TITLE
Fixed mistake in answer in exercise 8 structural testing

### DIFF
--- a/chapters/appendix/answers.md
+++ b/chapters/appendix/answers.md
@@ -348,7 +348,7 @@ For `"aa"` the expected output is `"a"`.
 **Exercise 8**
 
 
-Answer 4. is correct.
+Answer 4. is incorrect.
 The loop in the method makes it impossible to achieve 100% path coverage.
 This would require us to test all possible number of iterations.
 For the other answers we can come up with a test case: `"aXYa"`


### PR DESCRIPTION
The answer to exercise 8 currently says: "answer 4 is correct", but this should be "answer 4 is incorrect".
Since the question was: "which of the following 4 statements is not correct?"