### PR TITLE
Eliminate confusion for decision order

### DIFF
--- a/chapters/appendix/answers.md
+++ b/chapters/appendix/answers.md
@@ -449,9 +449,23 @@ Option 1 is correct.
 
 
 
-Option 1 is the correct one.
+Option 1 is the correct one. Consider the following table:
 
-Tests for A = (2,6), B = (2,4), C = (3, 4), (5, 6), (7,8). Thus, from the options, tests 2, 3, 4 and 6 are the only ones that achieve 100% MC/DC. Note that 2, 4, 5, 6 could also be a solution.
+<table>
+    <tr><th>Decision</th><th>A</th><th>B</th><th>C</th><th>(A & B) | C</th></tr>
+    <tr><td>1</td><td>T</td><td>T</td><td>T</td><td>T</td></tr>
+    <tr><td>2</td><td>T</td><td>T</td><td>F</td><td>T</td></tr>
+    <tr><td>3</td><td>T</td><td>F</td><td>T</td><td>T</td></tr>
+    <tr><td>4</td><td>T</td><td>F</td><td>F</td><td>F</td></tr>
+    <tr><td>5</td><td>F</td><td>T</td><td>T</td><td>T</td></tr>
+    <tr><td>6</td><td>F</td><td>T</td><td>F</td><td>F</td></tr>
+    <tr><td>7</td><td>F</td><td>F</td><td>T</td><td>T</td></tr>
+    <tr><td>8</td><td>F</td><td>F</td><td>F</td><td>F</td></tr>
+</table>
+
+Test pairs for `A = {(2,6)}`, `B = {(2,4)}` and `C = {(3, 4), (5, 6), (7,8)}`.
+Thus, from the options, tests 2, 3, 4 and 6 are the only ones that achieve 100% MC/DC.
+Note that 2, 4, 5, 6 could also be a solution.
 
 
 

--- a/chapters/testing-techniques/structural-testing.md
+++ b/chapters/testing-techniques/structural-testing.md
@@ -977,7 +977,9 @@ criterion if for every loop L:
 
 **Exercise 15.**
 Consider the expression `((A and B) or C)`.
-If we aim to achieve $$100\%$$ *Modified Condition / Decision Coverage* (MC/DC), the **minimum** set of tests we should select is:
+If we aim to achieve $$100\%$$ *Modified Condition / Decision Coverage* (MC/DC),
+the **minimum** set of tests we should select is
+(considering a table starting with `A = true`, `B = true`, `C = true`):
 
 1. {2, 3, 4, 6}
 2. {1, 3, 4, 6}


### PR DESCRIPTION
In exercise 15 of the Structural Testing, we are asked to find the correct option of decisions. In the question, it is not really stated that the table of the answers should be starting with TTT and ending with FFF. Also added a decision table to the answer sheet