### PR TITLE
Fix code from "Design by Contracts", exercise 1

### DIFF
--- a/chapters/testing-techniques/design-by-contracts.md
+++ b/chapters/testing-techniques/design-by-contracts.md
@@ -613,7 +613,7 @@ See the code below:
 ```java
 public Square squareAt(int x, int y) {
   assert x >= 0;
-  assert x < board.getWidth();
+  assert x < board.length;
   assert y >= 0;
   assert y < board[x].length;
   assert board != null;


### PR DESCRIPTION
The code given in the exercise apparently uses a two-dimensional array to store the fictive board (`board`).
On the third line however, the method `#getWidth()` is called on the array.
This PR changes that into simply just `.length`, as that is probably the intended expression.