### PR TITLE
Change title to match chapter name

### DIFF
--- a/chapters/appendix/answers.md
+++ b/chapters/appendix/answers.md
@@ -916,7 +916,7 @@ See https://martinfowler.com/bliki/TestPyramid.html !
 
 
 
-## Mock Objects
+## Test doubles
 
 **Exercise 1**
 


### PR DESCRIPTION
Changed the title from 'Mock Objects' to 'Test doubles' to match the chapter name.