### PR TITLE
Refactored @BeforeEach to final field initialization

### DIFF
--- a/chapters/pragmatic-testing/test-doubles.md
+++ b/chapters/pragmatic-testing/test-doubles.md
@@ -94,11 +94,7 @@ Without stubbing the `IssuedInvoices` class, the `InvoiceFilter` test would need
 
 ```java
 public class InvoiceFilterTest {
-  private IssuedInvoices invoices;
-
-  @BeforeEach public void open() {
-    invoices = new IssuedInvoices();
-  }
+  private final IssuedInvoices invoices = new IssuedInvoices();
 
   @AfterEach public void close() {
     if (invoices != null) invoices.close();

--- a/chapters/testing-techniques/design-by-contracts.md
+++ b/chapters/testing-techniques/design-by-contracts.md
@@ -567,14 +567,9 @@ Here, we define the abstract method that gives us a List.
 ```java
 public abstract class ListTest {
 
-  private List list;
+  private final List list = createList();
 
   protected abstract List createList();
-
-  @BeforeEach
-  public void setUp() {
-    list = createList();
-  }
 
   // Common List tests using list
 }

--- a/chapters/testing-techniques/specification-based-testing.md
+++ b/chapters/testing-techniques/specification-based-testing.md
@@ -116,12 +116,7 @@ Implementing this using JUnit gives the following code for the tests:
 ```java
 public class LeapYearTests {
 
-  private LeapYear leapYear;
-
-  @BeforeEach
-  public void setup() {
-    leapYear = new LeapYear();
-  }
+  private final LeapYear leapYear = new LeapYear();
 
   @Test
   public void leapYearsNotCenturialTest() {


### PR DESCRIPTION
Should fix #186, hope I didn't miss any chapters.

Did not touch the _refactoring_ subsection from the _test automation_ chapter, please let me know if any changes are desired there.

Also did not touch the **@ BeforeEach** in the _SQL testing_ chapter, since I deemed it necessary there.

Small note: in the _design-by-contracts_ chapter, `private (final) List list` should probably have the default or protected access modifier instead of private, as to be able to be accessed from within test classes which extend `ListTest`. Would be happy to make the change upon receiving confirmation.