### PR TITLE
Added JS Date clarification

### DIFF
--- a/chapters/testing-into-context/web-testing.md
+++ b/chapters/testing-into-context/web-testing.md
@@ -241,6 +241,15 @@ We first write some tests for the functions in `dateUtils.js` by creating an HTM
 
     <script src="dateUtils.js"></script>
     <script>
+        
+        /*
+        Some clarification about dates in JavaScript:
+        Months are zero-based, meaning that month 0 is January, month 1 is February etc.
+        This means that "new Date(2020, 1, 29)" actually constructs February 29th, instead
+        of January 29th, which would seem more obvious. Take this into account for this
+        and the following code snippets!
+        */
+        
         function assertEqual(expected, actual) {
             if (expected != actual) {
                 console.log("Expected " + expected + " but was " + actual);
@@ -468,14 +477,6 @@ For the utility functions, we can again write similar code to what we did with o
 
 ```js
 import { addOneDay, dateToString } from './dateUtils';
-
-/*
-Some clarification about dates in JavaScript:
-Months are zero-based, meaning that month 0 is January, month 1 is february etc.
-This means that "new Date(2020, 1, 29)" actually constructs February 29th, instead
-of January 29th, which would seem more obvious. Take this into account for this
-and the following code snippets!
-*/
 
 describe('addOneDay', () => {
   test('handles February 29th', () => {

--- a/chapters/testing-into-context/web-testing.md
+++ b/chapters/testing-into-context/web-testing.md
@@ -469,6 +469,14 @@ For the utility functions, we can again write similar code to what we did with o
 ```js
 import { addOneDay, dateToString } from './dateUtils';
 
+/*
+Some clarification about dates in JavaScript:
+Months are zero-based, meaning that month 0 is January, month 1 is february etc.
+This means that "new Date(2020, 1, 29)" actually constructs February 29th, instead
+of January 29th, which would seem more obvious. Take this into account for this
+and the following code snippets!
+*/
+
 describe('addOneDay', () => {
   test('handles February 29th', () => {
     const oldDate = new Date(2020, 1, 29);  // February 29th, 2020


### PR DESCRIPTION
Added a comment that clarifies that dates in JavaScript are zero-based, to avoid confusion. This is now added as a comment in the first code snippet where JavaScript dates are used.