### PR TITLE
Fix grammer nuance (Test Code Quality)

### DIFF
--- a/chapters/pragmatic-testing/test-code-quality.md
+++ b/chapters/pragmatic-testing/test-code-quality.md
@@ -31,7 +31,7 @@ Tests are the safety net of a developer. Whenever developers perform any mainten
 or evolution in the source code, they use the feedback of the test suite to understand
 whether the system is still working as expected. 
 The faster the developer gets feedback from their test code, the better. 
-On the other hand, slower test suites force developers to simply run the tests less often,
+Additionally, slower test suites force developers to simply run the tests less often,
 making them less effective. Therefore, good tests are fast.
 There is no hard line that separates slow from fast tests. It is fundamental to apply common sense.
 Once you are facing a slow test, you might consider to:


### PR DESCRIPTION
Using on the other hand implies that "slower test suites force developers to simply run the tests less often, making them less effective" is somehow opposed to "The faster the developer gets feedback from their test code, the better", where as both of these sentences re an argument in favor of fast test suits.
Using additionally makes more sense, and gives the text a better flow. Now the impression the reader gets is: fast tests give quick feedback **and** slow tests are run less often instead of:  fast tests give quick feedback **but** slow tests are run less often.