### PR TITLE
Fix of the forgotten space character

### DIFF
--- a/chapters/pragmatic-testing/test-code-quality.md
+++ b/chapters/pragmatic-testing/test-code-quality.md
@@ -332,7 +332,7 @@ public class Item {
 
 	@Override
 	public String toString() {
-		return "Product " + name + " times" + qty + " = " + finalAmount();
+		return "Product " + name + " times " + qty + " = " + finalAmount();
 	}
 }
 ```


### PR DESCRIPTION
Within the first example Item class' toString method, the space character after "times" is forgotten so it was " times", I changed it to " times ".