### PR TITLE
Changed assertion to assertTrue in exercise

### DIFF
--- a/chapters/pragmatic-testing/test-code-quality.md
+++ b/chapters/pragmatic-testing/test-code-quality.md
@@ -872,7 +872,7 @@ public void flightMileage() {
   // now try it with a canceled flight
   newFlight.cancel();
   boolean flightCanceledStatus = newFlight.isCancelled();
-  assertFalse(flightCanceledStatus);
+  assertTrue(flightCanceledStatus);
 }
 ```
 


### PR DESCRIPTION
I would argue that, if the flight is cancelled, the result of newFlight.isCancelled() should be `true`. It makes more sense to the reader in my opinion.