### PR TITLE
Fix mistake in soundness vs completeness

### DIFF
--- a/chapters/non-functional-testing/security-testing.md
+++ b/chapters/non-functional-testing/security-testing.md
@@ -202,7 +202,7 @@ Before we dive into further explanation of SAST and DAST techniques, let's look 
 The quality of testing tools is evaluated in a number of ways. You have already learnt about _code coverage_ in a previous chapter. Here, we discuss four new metrics that are often used in the context of security testing:
 Designing an ideal testing tool requires striking a balance between two measures: (a) Soundness, and (b) Completeness.
 
-**Soundness** dictates that there should be no False Negatives (FN) — no vulnerability should be skipped. This implies that no alarm is raised *IF* there is no existing vulnerability in the *System Under Test (SUT)*. **Completeness** dictates that there should be no False Positives (FP) — no false alarm should be raised. This implies that an alarm is raised *IF* a valid vulnerability is found.
+**Soundness** dictates that there should be no False Negatives (FN) — no false alarm should be raised. This implies that no alarm is raised *IF* there is no existing vulnerability in the *System Under Test (SUT)*. **Completeness** dictates that there should be no False Positives (FP) — no vulnerability should be skipped. This implies that an alarm is raised *IF* a valid vulnerability is found.
 
 A perfect testing tool is both sound and complete. However, this is an undecidable problem — given finite time, the tool will always be wrong for some input. In reality, tools often compromise of FPs or FNs.
 

--- a/chapters/non-functional-testing/security-testing.md
+++ b/chapters/non-functional-testing/security-testing.md
@@ -206,7 +206,7 @@ Designing an ideal testing tool requires striking a balance between two measures
 
 A perfect testing tool is both sound and complete. However, this is an undecidable problem — given finite time, the tool will always be wrong for some input. In reality, tools often compromise of FPs or FNs.
 
-Low FNs are ideal for security critical applications where a missed vulnerability can cause significant loss, e.g. banking apps. Low FPs are ideal for applications that don't have a lot of manpower to evaluate the correctness of each result.
+Low FPs are ideal for security critical applications where a missed vulnerability can cause significant loss, e.g. banking apps. Low FNs are ideal for applications that don't have a lot of manpower to evaluate the correctness of each result.
 
 Additionally, an ideal testing tool is **interpretable**: an analyst can trace the results to a solid cause, and are **scalable**: the tool can be used for large applications without compromising heavily on performance.
 


### PR DESCRIPTION
There is a mistake in the security testing chapter. Currently soundness is explained as "no vulnerability should be skipped" and completeness is explained as "no false alarm should be raised".

I corrected it to be the other way around:
completeness - no vulnerability should be skipped
soundness - no false alarm should be raised

Moreover, low False Positives  are ideal for security critical applications and low False Negatives are ideal for applications that don't have a lot of manpower. Not another way around, as it is currently in the book.