### PR TITLE
Roman numeral spelling correction

### DIFF
--- a/chapters/getting-started/test-automation.md
+++ b/chapters/getting-started/test-automation.md
@@ -30,7 +30,7 @@ All the production and test code used in this book can be found in the [code exa
 > Example: 7 is `VII`, 11 is `XI` and 101 is `CI`.
 > Some numbers need to make use of a subtractive notation to be represented.
 > For example we make 40 not by `XXXX`, but instead we use $50 - 10 = 40$ and have the roman number `XL`.
-> Other examples: 9 is `XI`, 40 is `XL`, 14 is `XIV`.
+> Other examples: 9 is `IX`, 40 is `XL`, 14 is `XIV`.
 > 
 > The letters should be ordered from the highest to the lowest value.
 > The values of each individual letter is added together.


### PR DESCRIPTION
the reference to number nine in roman numeral is wrong