### PR TITLE
Wrap LaTeX in $$

### DIFF
--- a/chapters/getting-started/test-automation.md
+++ b/chapters/getting-started/test-automation.md
@@ -29,7 +29,7 @@ All the production and test code used in this book can be found in the [code exa
 > For example we make 6 by using $$5 + 1 = 6$$ and have the roman number `VI`
 > Example: 7 is `VII`, 11 is `XI` and 101 is `CI`.
 > Some numbers need to make use of a subtractive notation to be represented.
-> For example we make 40 not by `XXXX`, but instead we use $50 - 10 = 40$ and have the roman number `XL`.
+> For example we make 40 not by `XXXX`, but instead we use $$50 - 10 = 40$$ and have the roman number `XL`.
 > Other examples: 9 is `IX`, 40 is `XL`, 14 is `XIV`.
 > 
 > The letters should be ordered from the highest to the lowest value.


### PR DESCRIPTION
A LaTeX expression was only wrapped in a single `$` and not `$$`. This resulted in it not being rendered correctly.