### PR TITLE
Add $$ wrapping to some percent coverages

### DIFF
--- a/chapters/appendix/answers.md
+++ b/chapters/appendix/answers.md
@@ -340,7 +340,7 @@ Ln in the diagram represents the line number of the code that is in the block or
 
 Option 1 is the false one.
 
-A minimal test suite that achieves 100\% (either basic or full) condition has the same number of tests as a minimal test suite that achieves 100\% branch coverage. All decisions have just a single branch, so condition coverage doesn't make a difference here. Moreover, a test case that exercises lines 1, 6, 7, 8, 9, 10 achieves around 54\% coverage (6/11).
+A minimal test suite that achieves $$100\%$$ (either basic or full) condition has the same number of tests as a minimal test suite that achieves $$100\%$$ branch coverage. All decisions have just a single branch, so condition coverage doesn't make a difference here. Moreover, a test case that exercises lines 1, 6, 7, 8, 9, 10 achieves around $$54\%$$ coverage (6/11).
 
 
 
@@ -433,9 +433,9 @@ L\<number\> represents the line numbers that the code blocks cover.
 **Exercise 7**
 
 
-A lot of input strings give 100% line coverage.
+A lot of input strings give $$100%$$ line coverage.
 A very simple one is `"aa"`.
-As long as the string is longer than one character and makes the condition in line 9 true, it will give 100% line coverage.
+As long as the string is longer than one character and makes the condition in line 9 true, it will give $$100%$$ line coverage.
 For `"aa"` the expected output is `"a"`.
 
 
@@ -443,7 +443,7 @@ For `"aa"` the expected output is `"a"`.
 
 
 Option 4 is the incorrect one.
-The loop in the method makes it impossible to achieve 100% path coverage.
+The loop in the method makes it impossible to achieve $$100%$$ path coverage.
 This would require us to test all possible number of iterations.
 For the other answers we can come up with a test case: `"aXYa"`
 


### PR DESCRIPTION
Some of the `100%` in answers were not wrapped in `$$` and therefore not rendered.